### PR TITLE
Feature/Quote Proposals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,3 @@ Homestead.json
 .phpstorm.meta.php
 _ide_helper.php
 _ide_helper_models.php
-
-.idea/jsLinters
-.idea/inspectionProfiles

--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ Homestead.json
 .phpstorm.meta.php
 _ide_helper.php
 _ide_helper_models.php
+
+.idea/jsLinters
+.idea/inspectionProfiles

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="Eslint" enabled="true" level="WARNING" enabled_by_default="true" />
+  </profile>
+</component>

--- a/.idea/jsLinters/eslint.xml
+++ b/.idea/jsLinters/eslint.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="EslintConfiguration">
+    <option name="fix-on-save" value="true" />
+  </component>
+</project>

--- a/app/Constants/QuoteProposalTypesConstant.php
+++ b/app/Constants/QuoteProposalTypesConstant.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Constants;
+
+final class QuoteProposalTypesConstant
+{
+    public const PENDING = 'PENDING';
+
+    public const ACCEPTED = 'ACCEPTED';
+
+    public const REJECTED = 'REJECTED';
+
+}

--- a/app/Constants/QuoteTypesConstant.php
+++ b/app/Constants/QuoteTypesConstant.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Constants;
+
+final class QuoteTypesConstant
+{
+    public const FAVORITE = 'FAVORITE';
+
+    public const PROPER = 'PROPER';
+
+}

--- a/app/Http/Controllers/Quotes/Proposals/CreateQuoteProposalController.php
+++ b/app/Http/Controllers/Quotes/Proposals/CreateQuoteProposalController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Controllers\Quotes\Proposals;
+
+use App\Constants\QuoteTypesConstant;
+use App\Constants\UserTypesAbilitiesConstant;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Quotes\CreateQuoteRequest;
+use App\Models\Quote;
+use App\Models\QuoteProposal;
+use Illuminate\Http\JsonResponse;
+
+class CreateQuoteProposalController extends Controller
+{
+
+    public function __construct()
+    {
+        $this->middleware(['auth:sanctum', 'abilities:' . UserTypesAbilitiesConstant::USER]);
+    }
+
+    public function __invoke(CreateQuoteRequest $request): JsonResponse
+    {
+        $data = $request->validated();
+
+        $quote = Quote::create(array_merge(
+            $data,
+            [
+                'type' => QuoteTypesConstant::PROPER,
+                'user_id' => auth()->id(),
+            ]
+        ));
+
+
+        $proposal = QuoteProposal::create([
+            "quote_id" => $quote->id
+        ]);
+
+        return response()->json(compact('quote', 'proposal'), 201);
+    }
+}

--- a/app/Http/Controllers/Quotes/Proposals/GetAllPendingForApprovalProposalsController.php
+++ b/app/Http/Controllers/Quotes/Proposals/GetAllPendingForApprovalProposalsController.php
@@ -7,7 +7,6 @@ use App\Constants\UserTypesAbilitiesConstant;
 use App\Http\Controllers\Controller;
 use App\Models\QuoteProposal;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
 
 class GetAllPendingForApprovalProposalsController extends Controller
 {
@@ -17,7 +16,7 @@ class GetAllPendingForApprovalProposalsController extends Controller
         $this->middleware(['auth:sanctum', 'abilities:' . UserTypesAbilitiesConstant::ADMIN]);
     }
 
-    public function __invoke(Request $request): JsonResponse
+    public function __invoke(): JsonResponse
     {
         return response()->json(QuoteProposal::where('status', QuoteProposalTypesConstant::PENDING)->get());
     }

--- a/app/Http/Controllers/Quotes/Proposals/GetAllPendingForApprovalProposalsController.php
+++ b/app/Http/Controllers/Quotes/Proposals/GetAllPendingForApprovalProposalsController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers\Quotes\Proposals;
+
+use App\Constants\QuoteProposalTypesConstant;
+use App\Constants\UserTypesAbilitiesConstant;
+use App\Http\Controllers\Controller;
+use App\Models\QuoteProposal;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class GetAllPendingForApprovalProposalsController extends Controller
+{
+
+    public function __construct()
+    {
+        $this->middleware(['auth:sanctum', 'abilities:' . UserTypesAbilitiesConstant::ADMIN]);
+    }
+
+    public function __invoke(Request $request): JsonResponse
+    {
+        return response()->json(QuoteProposal::where('status', QuoteProposalTypesConstant::PENDING)->get());
+    }
+}

--- a/app/Http/Controllers/Quotes/Proposals/ReviewQuoteProposalController.php
+++ b/app/Http/Controllers/Quotes/Proposals/ReviewQuoteProposalController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Controllers\Quotes\Proposals;
+
+use App\Constants\QuoteProposalTypesConstant;
+use App\Constants\UserTypesAbilitiesConstant;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\QuoteProposals\ReviewQuoteProposalRequest;
+use App\Models\QuoteProposal;
+use Illuminate\Http\JsonResponse;
+
+class ReviewQuoteProposalController extends Controller
+{
+
+    public function __construct()
+    {
+        $this->middleware(['auth:sanctum', 'abilities:' . UserTypesAbilitiesConstant::ADMIN]);
+    }
+
+    public function __invoke(ReviewQuoteProposalRequest $request, QuoteProposal $quote_proposal): JsonResponse
+    {
+        $data = $request->validated();
+
+        $quote_proposal->status = $data['status'];
+        $quote_proposal->rejected_reason = $data['rejected_reason'];
+
+        if ($data['status'] === QuoteProposalTypesConstant::REJECTED) {
+            $quote_proposal->rejected_at = now();
+        }
+
+        $quote_proposal->save();
+
+        return response()->json([], 204);
+    }
+}

--- a/app/Http/Requests/QuoteProposals/ReviewQuoteProposalRequest.php
+++ b/app/Http/Requests/QuoteProposals/ReviewQuoteProposalRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests\QuoteProposals;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ReviewQuoteProposalRequest extends FormRequest
+{
+
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'rejected_reason' => 'nullable|string',
+            'status' => 'required|string',
+        ];
+    }
+}

--- a/app/Http/Requests/QuoteProposals/ReviewQuoteProposalRequest.php
+++ b/app/Http/Requests/QuoteProposals/ReviewQuoteProposalRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\QuoteProposals;
 
+use App\Constants\QuoteProposalTypesConstant;
 use Illuminate\Foundation\Http\FormRequest;
 
 class ReviewQuoteProposalRequest extends FormRequest
@@ -16,7 +17,7 @@ class ReviewQuoteProposalRequest extends FormRequest
     {
         return [
             'rejected_reason' => 'nullable|string',
-            'status' => 'required|string',
+            'status' => 'required|in:' . QuoteProposalTypesConstant::PENDING . ',' . QuoteProposalTypesConstant::ACCEPTED . ',' . QuoteProposalTypesConstant::REJECTED,
         ];
     }
 }

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -20,7 +20,7 @@ class Category extends Model
 
     public function quotes(): HasMany
     {
-        return $this->hasMany(FavoriteQuote::class);
+        return $this->hasMany(Quote::class);
     }
 
     public function users(): BelongsToMany

--- a/app/Models/Quote.php
+++ b/app/Models/Quote.php
@@ -5,11 +5,12 @@ namespace App\Models;
 use App\Traits\UsesUuid;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 
 /**
- * @mixin IdeHelperFavoriteQuote
+ * @mixin IdeHelperQuote
  */
-class FavoriteQuote extends Model
+class Quote extends Model
 {
     use UsesUuid;
 
@@ -36,5 +37,10 @@ class FavoriteQuote extends Model
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function quote_proposals(): HasOne
+    {
+        return $this->hasOne(QuoteProposal::class);
     }
 }

--- a/app/Models/QuoteProposal.php
+++ b/app/Models/QuoteProposal.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Models;
+
+use App\Traits\UsesUuid;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @mixin IdeHelperQuoteProposal
+ */
+class QuoteProposal extends Model
+{
+    use HasFactory, UsesUuid;
+
+    protected $fillable = [
+        "status",
+        "rejected_reason",
+        "rejected_at",
+        "quote_id"
+    ];
+
+    protected $hidden = [
+        'updated_at'
+    ];
+
+    protected $casts = [
+        'created_at' => 'date:d-m-Y',
+        'rejected_at' => 'date:d-m-Y'
+    ];
+
+    public function quote(): BelongsTo
+    {
+        return $this->belongsTo(Quote::class);
+    }
+
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -40,7 +40,7 @@ class User extends Authenticatable
 
     public function favoriteQuotes(): HasMany
     {
-        return $this->hasMany(FavoriteQuote::class);
+        return $this->hasMany(Quote::class);
     }
 
     public function categories(): BelongsToMany

--- a/database/migrations/2023_05_30_211335_rename_table_favorite_quotes.php
+++ b/database/migrations/2023_05_30_211335_rename_table_favorite_quotes.php
@@ -1,0 +1,18 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+
+    public function up(): void
+    {
+        Schema::rename('favorite_quotes', 'quotes');
+    }
+
+
+    public function down(): void
+    {
+        Schema::rename('quotes', 'favorite_quotes');
+    }
+};

--- a/database/migrations/2023_05_30_211533_add_type_column_to_quotes_table.php
+++ b/database/migrations/2023_05_30_211533_add_type_column_to_quotes_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use App\Constants\QuoteTypesConstant;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+
+    public function up(): void
+    {
+        Schema::table('quotes', function (Blueprint $table) {
+            $table->char('type', 8)->default(QuoteTypesConstant::FAVORITE);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('quotes', function (Blueprint $table) {
+            $table->dropColumn('type');
+        });
+    }
+};

--- a/database/migrations/2023_05_30_211933_create_quote_proposals_table.php
+++ b/database/migrations/2023_05_30_211933_create_quote_proposals_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use App\Constants\QuoteProposalTypesConstant;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+
+    public function up(): void
+    {
+        Schema::create('quote_proposals', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->char('status', 8)->default(QuoteProposalTypesConstant::PENDING);
+            $table->string('rejected_reason')->nullable();
+            $table->date('rejected_at')->nullable();
+            $table->foreignUuid('quote_id')->constrained();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('quote_proposals');
+    }
+};

--- a/routes/api/quotes.php
+++ b/routes/api/quotes.php
@@ -2,6 +2,12 @@
 
 use App\Http\Controllers\Quotes\CreateQuoteController;
 use App\Http\Controllers\Quotes\GetUserFavoriteQuotesController;
+use App\Http\Controllers\Quotes\Proposals\CreateQuoteProposalController;
+use App\Http\Controllers\Quotes\Proposals\GetAllPendingForApprovalProposalsController;
+use App\Http\Controllers\Quotes\Proposals\ReviewQuoteProposalController;
 
 Route::post('/', CreateQuoteController::class);
 Route::get('/favorite', GetUserFavoriteQuotesController::class);
+Route::get('/proposal', GetAllPendingForApprovalProposalsController::class);
+Route::post('/proposal', CreateQuoteProposalController::class);
+Route::patch('/proposal/{quote_proposal}', ReviewQuoteProposalController::class);

--- a/routes/api/quotes.php
+++ b/routes/api/quotes.php
@@ -10,4 +10,4 @@ Route::post('/', CreateQuoteController::class);
 Route::get('/favorite', GetUserFavoriteQuotesController::class);
 Route::get('/proposal', GetAllPendingForApprovalProposalsController::class);
 Route::post('/proposal', CreateQuoteProposalController::class);
-Route::patch('/proposal/{quote_proposal}', ReviewQuoteProposalController::class);
+Route::post('/proposal/{quote_proposal}', ReviewQuoteProposalController::class);

--- a/routes/api/quotes.php
+++ b/routes/api/quotes.php
@@ -10,4 +10,4 @@ Route::post('/', CreateQuoteController::class);
 Route::get('/favorite', GetUserFavoriteQuotesController::class);
 Route::get('/proposal', GetAllPendingForApprovalProposalsController::class);
 Route::post('/proposal', CreateQuoteProposalController::class);
-Route::post('/proposal/{quote_proposal}', ReviewQuoteProposalController::class);
+Route::post('/proposal/{quote_proposal}/review', ReviewQuoteProposalController::class);


### PR DESCRIPTION
#4 

- Migrations created for table `quote_proposals` and `quotes` to rename it and add column `type`.
- Model `QuoteProposal created` with relation belongTo with `Quote`.
- Model `Quote` renamed and relation hasOne with `QuoteProposal` added.
- `QuoteProposal`  controllers added: `GetAllPendingApprovalProposals`, `CreateQuoteProposal` and `ReviewQuoteProposal`.
- `Review Quote Proposal` request added, to validate the status and re rejected_reason.
- Middlewares added in the Quote Proposal Controllers, in their constructors.

### API ENDPOINTS
- Get all pending approval proposals. [Admin ability]
- Create quote proposal. [User ability]
- ReviewQuoteProposal. [Admin ability]