### PR TITLE
Feature/Delete favorite quotes

### DIFF
--- a/app/Http/Controllers/Quotes/DeleteFavoriteQuoteController.php
+++ b/app/Http/Controllers/Quotes/DeleteFavoriteQuoteController.php
@@ -19,11 +19,11 @@ class DeleteFavoriteQuoteController extends Controller
     public function __invoke(Quote $quote): JsonResponse
     {
         if ($quote->type !== QuoteTypesConstant::FAVORITE) {
-            return response()->json('Conflict', 409);
+            abort(409, 'Conflict');
         }
 
         if ($quote->user->id !== auth()->id()) {
-            return response()->json('Forbidden', 403);
+            abort(403, 'Forbidden');
         }
 
         $quote->delete();

--- a/app/Http/Controllers/Quotes/DeleteFavoriteQuoteController.php
+++ b/app/Http/Controllers/Quotes/DeleteFavoriteQuoteController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Http\Controllers\Quotes;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class DeleteFavoriteQuoteController extends Controller
+{
+
+    public function __invoke(Request $request)
+    {
+
+    }
+}

--- a/app/Http/Controllers/Quotes/DeleteFavoriteQuoteController.php
+++ b/app/Http/Controllers/Quotes/DeleteFavoriteQuoteController.php
@@ -19,11 +19,11 @@ class DeleteFavoriteQuoteController extends Controller
     public function __invoke(Quote $quote): JsonResponse
     {
         if ($quote->type !== QuoteTypesConstant::FAVORITE) {
-            abort(409, 'Conflict');
+            abort(409);
         }
 
         if ($quote->user->id !== auth()->id()) {
-            abort(403, 'Forbidden');
+            abort(403);
         }
 
         $quote->delete();

--- a/app/Http/Controllers/Quotes/DeleteFavoriteQuoteController.php
+++ b/app/Http/Controllers/Quotes/DeleteFavoriteQuoteController.php
@@ -2,14 +2,31 @@
 
 namespace App\Http\Controllers\Quotes;
 
+use App\Constants\QuoteTypesConstant;
+use App\Constants\UserTypesAbilitiesConstant;
 use App\Http\Controllers\Controller;
-use Illuminate\Http\Request;
+use App\Models\Quote;
+use Illuminate\Http\JsonResponse;
 
 class DeleteFavoriteQuoteController extends Controller
 {
 
-    public function __invoke(Request $request)
+    public function __construct()
     {
+        $this->middleware(['auth:sanctum', 'abilities:' . UserTypesAbilitiesConstant::USER]);
+    }
 
+    public function __invoke(Quote $quote): JsonResponse
+    {
+        if ($quote->type !== QuoteTypesConstant::FAVORITE) {
+            return response()->json('Conflict', 409);
+        }
+
+        if ($quote->user->id !== auth()->id()) {
+            return response()->json('Forbidden', 403);
+        }
+
+        $quote->delete();
+        return response()->json([], 204);
     }
 }

--- a/routes/api/quotes.php
+++ b/routes/api/quotes.php
@@ -1,12 +1,14 @@
 <?php
 
 use App\Http\Controllers\Quotes\CreateQuoteController;
+use App\Http\Controllers\Quotes\DeleteFavoriteQuoteController;
 use App\Http\Controllers\Quotes\GetUserFavoriteQuotesController;
 use App\Http\Controllers\Quotes\Proposals\CreateQuoteProposalController;
 use App\Http\Controllers\Quotes\Proposals\GetAllPendingForApprovalProposalsController;
 use App\Http\Controllers\Quotes\Proposals\ReviewQuoteProposalController;
 
 Route::post('/', CreateQuoteController::class);
+Route::delete('/{quote}', DeleteFavoriteQuoteController::class);
 Route::get('/favorite', GetUserFavoriteQuotesController::class);
 Route::get('/proposal', GetAllPendingForApprovalProposalsController::class);
 Route::post('/proposal', CreateQuoteProposalController::class);


### PR DESCRIPTION
#8 
- Controller `DeleteFavoriteQuote` added.
- All PHPDocs were removed.
- Middleware defined in the construct function with ability [isUser].
- Restrictions were added: Status `409` if the quote isn't `FAVORITE` and `403` if the quote doesn't belong to the user.

### API ENDPOINT
- Delete favorite quote `/{quote}`.